### PR TITLE
#2: Fixes Version/Account Headers

### DIFF
--- a/lib/WebService/Stripe.pm
+++ b/lib/WebService/Stripe.pm
@@ -6,6 +6,7 @@ with 'WebService::Client';
 
 use Carp qw(croak);
 use Method::Signatures;
+use constant { MARKETPLACES_MIN_VERSION => '2014-11-05' };
 
 has api_key => (
     is       => 'ro',
@@ -14,7 +15,7 @@ has api_key => (
 
 has version => (
     is      => 'ro',
-    default => '2014-11-05',
+    default => MARKETPLACES_MIN_VERSION,
 );
 
 has '+base_url' => ( default => 'https://api.stripe.com' );
@@ -23,7 +24,7 @@ has '+content_type' => ( default => 'application/x-www-form-urlencoded' );
 
 method BUILD(@args) {
     $self->ua->default_headers->authorization_basic( $self->api_key, '' );
-    $self->ua->default_header( 'Stripe-Version' => '2014-11-05' );
+    $self->ua->default_header( 'Stripe-Version' => $self->version );
 }
 
 method next(HashRef $thing, HashRef :$query) {

--- a/t/05-headers.t
+++ b/t/05-headers.t
@@ -1,0 +1,12 @@
+use WebService::Stripe;
+use Test::Modern;
+
+subtest "Default Header Values" => sub {
+    my $stripe = WebService::Stripe->new(api_key => 'foo');
+    like $stripe->ua->default_header('Authorization'), qr/^Basic.*$/,
+        '... Uses HTTP Basic Auth';
+    is $stripe->ua->default_header('Stripe-Version'), '2014-11-05',
+        '... Stripe-Version header defaults to "2014-11-05"';
+};
+
+done_testing;


### PR DESCRIPTION
- Correctly sets Stripe-Version header to the ->version attribute value
- Uses constant "MARKETPLACES_MIN_VERSION" instead of magic version string
