### PR TITLE
Issue 4: Support GET /balance

### DIFF
--- a/lib/WebService/Stripe.pm
+++ b/lib/WebService/Stripe.pm
@@ -39,6 +39,10 @@ method create_customer(HashRef $data={}) {
     return $self->post( "/v1/customers", $data );
 }
 
+method get_balance() {
+    return $self->get( "/v1/balance" );
+}
+
 method get_customer(Str $id) {
     return $self->get( "/v1/customers/$id" );
 }

--- a/t/06-balance.t
+++ b/t/06-balance.t
@@ -1,0 +1,13 @@
+use Test::Modern;
+use t::lib::Common qw(skip_unless_has_secret stripe);
+
+skip_unless_has_secret;
+
+subtest "Balance for the Stripe marketplace" => sub {
+    my $bal = stripe->get_balance;
+    cmp_deeply $bal, TD->superhashof({ object => 'balance' }),
+        '... Fetched balance'
+        or diag explain $bal;
+};
+
+done_testing;


### PR DESCRIPTION
Adds support for the `GET /v1/balance` endpoint, with a test. Requires ability to set the Stripe-Account header to be useful in all contexts.
