### PR TITLE
Add Testing Constants

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -38,7 +38,7 @@ my %WriteMakefileArgs = (
     "strict" => 0,
     "warnings" => 0
   },
-  "VERSION" => "0.0800",
+  "VERSION" => "0.0801",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ WebService::Stripe - Stripe API bindings
 
 # VERSION
 
-version 0.0800
+version 0.0801
 
 # SYNOPSIS
 
@@ -13,6 +13,11 @@ version 0.0800
         version => '2014-11-05', # optional
     );
     my $customer = $stripe->get_customer('cus_57eDUiS93cycyH');
+
+# TESTING
+
+Set the PERL\_STRIPE\_TEST\_API\_KEY environment variable to your Stripe test
+secret, then run tests as you normally would using prove.
 
 # HEADERS
 

--- a/dist.ini
+++ b/dist.ini
@@ -5,7 +5,7 @@ license = Perl_5
 copyright_holder = Tilt, Inc
 copyright_year   = 2014
 
-version = 0.0800
+version = 0.0801
 
 [@Filter]
 -bundle = @Basic

--- a/lib/WebService/Stripe.pm
+++ b/lib/WebService/Stripe.pm
@@ -158,6 +158,11 @@ method get_bitcoin_receiver(Str $id, :$headers) {
     );
     my $customer = $stripe->get_customer('cus_57eDUiS93cycyH');
 
+=head1 TESTING
+
+Set the PERL_STRIPE_TEST_API_KEY environment variable to your Stripe test
+secret, then run tests as you normally would using prove.
+
 =head1 HEADERS
 
 WebService::Stripe supports passing custom headers to any API request by passing a hash of header values as the optional C<headers> named parameter:

--- a/t/02-charges.t
+++ b/t/02-charges.t
@@ -1,5 +1,5 @@
 use Test::Modern;
-use t::lib::Common qw(skip_unless_has_secret stripe);
+use t::lib::Common qw(skip_unless_has_secret stripe :constants);
 use JSON;
 
 skip_unless_has_secret;
@@ -7,7 +7,7 @@ skip_unless_has_secret;
 my $customer = stripe->create_customer({ description => 'foo' });
 my $card = stripe->create_card(
     {
-        'card[number]'    => '5105105105105100',
+        'card[number]'    => STRIPE_CARD_VISA,
         'card[exp_month]' => 12,
         'card[exp_year]'  => 2020,
     },

--- a/t/03-banks.t
+++ b/t/03-banks.t
@@ -1,5 +1,5 @@
 use Test::Modern;
-use t::lib::Common qw(skip_unless_has_secret stripe);
+use t::lib::Common qw(:constants skip_unless_has_secret stripe);
 use JSON;
 
 skip_unless_has_secret;
@@ -13,8 +13,8 @@ subtest 'create bank' => sub {
         {
             'bank_account[country]'        => 'CA',
             'bank_account[currency]'       => 'cad',
-            'bank_account[routing_number]' => '00022-001',
-            'bank_account[account_number]' => '000123456789',
+            'bank_account[routing_number]' => STRIPE_BANK_US_ROUTING_NO,
+            'bank_account[account_number]' => STRIPE_BANK_ACCOUNT,
         },
         account_id => $account->{id},
     );

--- a/t/04-transfers.t
+++ b/t/04-transfers.t
@@ -1,5 +1,5 @@
 use Test::Modern;
-use t::lib::Common qw(skip_unless_has_secret stripe);
+use t::lib::Common qw(:constants skip_unless_has_secret stripe);
 use JSON qw(from_json);
 
 skip_unless_has_secret;
@@ -12,8 +12,8 @@ my $bank = stripe->add_bank(
     {
         'bank_account[country]'        => 'CA',
         'bank_account[currency]'       => 'cad',
-        'bank_account[routing_number]' => '00022-001',
-        'bank_account[account_number]' => '000123456789',
+        'bank_account[routing_number]' => STRIPE_BANK_US_ROUTING_NO,
+        'bank_account[account_number]' => STRIPE_BANK_ACCOUNT,
     },
     account_id => $account->{id},
 );

--- a/t/07-options.t
+++ b/t/07-options.t
@@ -1,5 +1,5 @@
 use Test::Modern;
-use t::lib::Common qw(skip_unless_has_secret stripe);
+use t::lib::Common qw(:constants skip_unless_has_secret stripe);
 
 skip_unless_has_secret;
 
@@ -9,7 +9,7 @@ my $acct = stripe->create_account({
 });
 my $cust = stripe->create_customer(undef);
 my $card = stripe->create_card({
-    'card[number]'    => '5105105105105100',
+    'card[number]'    => STRIPE_CARD_AMEX,
     'card[exp_month]' => 12,
     'card[exp_year]'  => 2020,
 }, customer_id => $cust->{id});
@@ -46,7 +46,7 @@ subtest 'Use stripe_account to associate customers to an account' => sub {
 
     my $acct_cust = stripe->create_customer(undef, %headers);
     my $acct_card_tok = stripe->create_token({
-        'card[number]'    => '5105105105105100',
+        'card[number]'    => STRIPE_CARD_AMEX,
         'card[exp_month]' => 12,
         'card[exp_year]'  => 2020,
     }, %headers);

--- a/t/lib/Common.pm
+++ b/t/lib/Common.pm
@@ -5,7 +5,58 @@ use Exporter qw(import);
 use Test::More import => [qw(plan)];
 use WebService::Stripe;
 
-our @EXPORT_OK = qw( skip_unless_has_secret stripe );
+my %constants;
+BEGIN {
+    %constants = (
+        # Card Issuers
+        STRIPE_CARD_AMEX               => '378282246310005',
+        STRIPE_CARD_AMEX_ALT           => '371449635398431',
+        STRIPE_CARD_DINERS_CLUB        => '30569309025904',
+        STRIPE_CARD_DINERS_CLUB_ALT    => '38520000023237',
+        STRIPE_CARD_DISCOVER           => '6011111111111117',
+        STRIPE_CARD_DISCOVER_ALT       => '6011000990139424',
+        STRIPE_CARD_JCB                => '3530111333300000',
+        STRIPE_CARD_JCB_ALT            => '3566002020360505',
+        STRIPE_CARD_MASTERCARD         => '5555555555554444',
+        STRIPE_CARD_MASTERCARD_DEBIT   => '5200828282828210',
+        STRIPE_CARD_MASTERCARD_PREPAID => '5105105105105100',
+        STRIPE_CARD_VISA               => '4242424242424242',
+        STRIPE_CARD_VISA_ALT           => '4012888888881881',
+        STRIPE_CARD_VISA_DEBIT         => '4000056655665556',
+        STRIPE_CARD_VISA_DEBIT_ALT     => '4000056655665564', # Transfers will fail
+        # Card Scenarios
+        STRIPE_CARD_BYPASS_BALANCE   => '4000000000000077',
+        STRIPE_CARD_ADDR_FAIL        => '4000000000000010',
+        STRIPE_CARD_LINE1_FAIL       => '4000000000000028',
+        STRIPE_CARD_ZIP_FAIL         => '4000000000000036',
+        STRIPE_CARD_ADDR_UNAVAILABLE => '4000000000000044',
+        STRIPE_CARD_CVC_FAIL         => '4000000000000101',
+        STRIPE_CARD_CHARGE_FAIL      => '4000000000000341',
+        STRIPE_CARD_DECLINED         => '4000000000000002',
+        STRIPE_CARD_INCORRECT_CVC    => '4000000000000127',
+        STRIPE_CARD_EXPIRED          => '4000000000000069',
+        STRIPE_CARD_PROC_ERROR       => '4000000000000119',
+        STRIPE_CARD_DISPUTED         => '4000000000000259',
+        # Dispute Evidence
+        STRIPE_DISPUTE_WINNING => 'winning_evidence',
+        STRIPE_DISPUTE_LOSING  => 'losing_evidence',
+        # Tax ID
+        STRIPE_TAX_ID_VALID   => '000000000',
+        STRIPE_TAX_ID_INVALID => '111111111',
+        # Banking
+        STRIPE_BANK_US_ROUTING_NO              => '110000000',
+        STRIPE_BANK_ACCOUNT                    => '000123456789',
+        STRIPE_BANK_ACCOUNT_NOT_EXISTS         => '000111111116',
+        STRIPE_BANK_ACCOUNT_CLOSED             => '000111111113',
+        STRIPE_BANK_ACCOUNT_INSUFFICIENT_FUNDS => '000222222227',
+        STRIPE_BANK_ACCOUNT_NOT_AUTHORIZED     => '000333333335',
+        STRIPE_BANK_ACCOUNT_INVALID_CURRENCY   => '000444444440',
+    );
+}
+use constant \%constants;
+
+our @EXPORT_OK   = (qw( skip_unless_has_secret stripe ), keys %constants);
+our %EXPORT_TAGS = (constants => [ keys %constants ]);
 
 sub skip_unless_has_secret {
     plan skip_all => 'PERL_STRIPE_TEST_API_KEY is required' unless api_key();


### PR DESCRIPTION
Adds constants for all of Stripe's documented test cards, bank accounts, etc. See: https://stripe.com/docs/testing.