### PR TITLE
Standardize Interfaces

### DIFF
--- a/t/01-customers.t
+++ b/t/01-customers.t
@@ -22,14 +22,14 @@ subtest 'basic stuff' => sub {
 };
 
 subtest 'create customer with no data' => sub {
-    my $cust = stripe->create_customer({});
+    my $cust = stripe->create_customer;
     ok $cust->{id},
         '... Created a customer with no data';
 };
 
 subtest 'Add a funding source to a customer' => sub {
-    my $cust = stripe->create_customer({});
-    my $card = stripe->add_source($cust, {
+    my $cust = stripe->create_customer;
+    my $card = stripe->add_source($cust->{'id'}, {
         "source[object]"    => "card",
         "source[exp_month]" => "12",
         "source[exp_year]"  => "2020",

--- a/t/02-charges.t
+++ b/t/02-charges.t
@@ -5,14 +5,11 @@ use JSON;
 skip_unless_has_secret;
 
 my $customer = stripe->create_customer({ description => 'foo' });
-my $card = stripe->create_card(
-    {
-        'card[number]'    => STRIPE_CARD_VISA,
-        'card[exp_month]' => 12,
-        'card[exp_year]'  => 2020,
-    },
-    customer_id => $customer->{id}
-);
+my $card = stripe->create_card($customer->{'id'}, {
+    'card[number]'    => STRIPE_CARD_VISA,
+    'card[exp_month]' => 12,
+    'card[exp_year]'  => 2020,
+});
 
 subtest 'create charge' => sub {
     my $charge = stripe->create_charge({
@@ -31,14 +28,14 @@ subtest 'create charge' => sub {
         }),
         'created charge';
 
-    $charge = stripe->get_charge($charge, query => { expand => ['customer'] });
+    $charge = stripe->get_charge($charge->{'id'}, { expand => ['customer'] });
     cmp_deeply $charge->{customer}, TD->superhashof({
         object => 'customer',
         id     => $customer->{id},
     }),
         '... Fetched the charge with expanded "customer" relation';
 
-    $charge = stripe->update_charge($charge, {
+    $charge = stripe->update_charge($charge->{'id'}, {
         description     => 'Foobar',
         'metadata[bar]' => 'baz',
     });

--- a/t/03-banks.t
+++ b/t/03-banks.t
@@ -9,17 +9,15 @@ subtest 'create bank' => sub {
         managed => 'true',
         country => 'CA',
     });
-    my $bank = stripe->add_bank(
-        {
-            'bank_account[country]'        => 'CA',
-            'bank_account[currency]'       => 'cad',
-            'bank_account[routing_number]' => STRIPE_BANK_US_ROUTING_NO,
-            'bank_account[account_number]' => STRIPE_BANK_ACCOUNT,
-        },
-        account_id => $account->{id},
-    );
+    my $bank = stripe->add_bank($account->{'id'}, {
+        'bank_account[country]'        => 'CA',
+        'bank_account[currency]'       => 'cad',
+        'bank_account[routing_number]' => STRIPE_BANK_US_ROUTING_NO,
+        'bank_account[account_number]' => STRIPE_BANK_ACCOUNT,
+    });
     cmp_deeply $bank => TD->superhashof({ last4 => 6789 }), 'created bank';
-    is stripe->get_account($account->{id})->{bank_accounts}{total_count} => 1;
+    is stripe->get_account($account->{'id'})->{bank_accounts}{total_count}, 1,
+        '... Added a bank to the correct Stripe Account';
 };
 
 done_testing;

--- a/t/08-file-upload.t
+++ b/t/08-file-upload.t
@@ -11,12 +11,15 @@ my $acct = stripe->create_account({
 subtest 'upload_identity_document' => sub {
     subtest "Client can upload and attach a JPG identity document" => sub {
         my $jpg_path = "./documents/valid.jpg";
-        my $file = stripe->upload_identity_document( $acct, $jpg_path );
+        my $file = stripe->upload_identity_document({
+            filepath       => $jpg_path,
+            stripe_account => $acct->{'id'},
+        });
         like $file->{id}, qr/file_\w+/,
             '... Uploaded the file';
 
-        $acct = stripe->update_account( $acct->{id}, data => {
-            'legal_entity[verification][document]' => $file->{id},
+        $acct = stripe->update_account($acct->{id}, {
+            'legal_entity[verification][document]' => $file->{'id'},
         });
         is $acct->{legal_entity}{verification}{document}, $file->{id},
             '... Linked uploaded file to an account';

--- a/t/09-refunds.t
+++ b/t/09-refunds.t
@@ -5,14 +5,11 @@ use JSON;
 skip_unless_has_secret;
 
 my $customer = stripe->create_customer({ description => 'foo' });
-my $card = stripe->create_card(
-    {
-        'card[number]'    => STRIPE_CARD_VISA,
-        'card[exp_month]' => 12,
-        'card[exp_year]'  => 2020,
-    },
-    customer_id => $customer->{id}
-);
+my $card = stripe->create_card($customer->{id}, {
+    'card[number]'    => STRIPE_CARD_VISA,
+    'card[exp_month]' => 12,
+    'card[exp_year]'  => 2020,
+});
 
 subtest 'refund a hold' => sub {
     my $charge = stripe->create_charge({


### PR DESCRIPTION
Standardizes all method interfaces to use the `$data, $opts = {}` pattern. For some methods, $data is required. If scoping parameters are required (e.g. when updating a bank account, you need both the bank and account IDs) then those parameters are passed first and are required.