### PR TITLE
support hashes in posts

### DIFF
--- a/lib/WebService/Stripe.pm
+++ b/lib/WebService/Stripe.pm
@@ -7,6 +7,7 @@ with 'WebService::Client';
 use Carp qw(croak);
 use HTTP::Request::Common qw( POST );
 use Method::Signatures;
+use Data::NestedParams;
 use constant {
     FILE_UPLOADS_URL         => 'https://uploads.stripe.com/v1/files',
     FILE_PURPOSE_ID_DOCUMENT => 'identity_document',
@@ -16,6 +17,14 @@ use constant {
 has api_key => (
     is       => 'ro',
     required => 1,
+);
+
+has serializer => (
+    is       => 'ro',
+    default  => sub {
+        my ($data, %args) = @_;
+        return collapse_nested_params($data);
+    }
 );
 
 has version => (


### PR DESCRIPTION
Some requests, such as update_account require the posting of hash data. For example:

my $response = $stripe->update_account($user_id, data => {
    debit_negative_balances     => 'true',
    decline_charge_on           => {
        avs_failure     => 'true',
        cvc_failure     => 'true',
    },  
});

And that data must be formatted using a nested hash syntax like Ruby on Rails. For example, the request above becomes:

debit_negative_balances=true&decline_charge_on[avs_failure]=true&decline_charge_on[cvc_failure]=true

The Data::NestedParams module does this formatting. Since Stripe requires this, it seems like it should be the built in serializer, rather than the one in WebService::Client.