### PR TITLE
CI: Faster build process

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,14 @@
+machine:
+  environment:
+    PATH: ~/perl5/bin:$PATH
 dependencies:
-  post:
-    - curl -L https://cpanmin.us | perl - --sudo App::cpanminus
-    - cpanm -nS local::lib
-    - cpanm -nS TAP::Parser
-    - cpanm -nL locallib --installdeps .
+  cache_directories:
+    - ~/perl5
+  pre:
+    - if ! hash perl 2>/dev/null; then sudo apt-get update -qq; sudo apt-get install perl; fi
+    - if ! hash cpanm 2>/dev/null; then curl -L https://cpanmin.us | perl - -l ~/perl5 App::cpanminus local::lib; fi
+    - if ! grep -q local::lib ~/.bashrc; then echo "eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)" >> ~/.bashrc; fi
+    - cpanm --quiet --notest --skip-satisfied --skip-installed --installdeps .
 test:
-  post:
-    - prove -lr -j 4 -Mlocal::lib=locallib t/*
+  override:
+    - prove --lib --recurse --jobs 4 t/*


### PR DESCRIPTION
This commit adds smarter dependency installation and caching to our CI script, bringing build times down from a few minutes to ~20-30s. 