### PR TITLE
Recipient Support

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -36,7 +36,7 @@ my %WriteMakefileArgs = (
     "strict" => 0,
     "warnings" => 0
   },
-  "VERSION" => "1.0000",
+  "VERSION" => "1.0100",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/README.md
+++ b/README.md
@@ -97,6 +97,34 @@ Example:
         ...
     }
 
+## create\_recipient
+
+    create_recipient($data)
+
+Creates a recipient.
+The `$data` hashref is required and must contain at least `name` and
+`type` (which can be `individual` or `corporate` as per Stripe's
+documentation), but can contain more (see Stripe Docs).
+Returns the recipient.
+
+Example:
+
+    $recipient = $stripe->create_recipient({
+        name => 'John Doe',
+        type => 'individual,
+    });
+
+## get\_recipient
+
+    get_recipient($id)
+
+Retrieves a recipient by id.
+Returns the recipient.
+
+Example:
+
+    $recipient = $stripe->get_recipient('rcp_123');
+
 ## create\_card
 
     create_card($data, customer_id => 'cus_123')

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ WebService::Stripe - Stripe API bindings
 
 # VERSION
 
-version 1.0000
+version 1.0100
 
 # SYNOPSIS
 

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Perl_5
 copyright_holder = Tilt, Inc
 copyright_year   = 2014
 
-version = 1.0000
+version = 1.0100
 
 [@Filter]
 -bundle = @Basic

--- a/lib/WebService/Stripe.pm
+++ b/lib/WebService/Stripe.pm
@@ -54,6 +54,14 @@ method create_customer(Maybe[HashRef] $data, :$headers) {
     return $self->post( "/v1/customers", $data, headers => $headers );
 }
 
+method create_recipient(HashRef $data, :$headers) {
+    return $self->post( "/v1/recipients", $data, headers => $headers );
+}
+
+method get_recipient(Str $id, :$headers) {
+    return $self->get( "/v1/recipients/$id", {}, headers => $headers );
+}
+
 method get_application_fee(Str $id, :$headers) {
     return $self->get( "/v1/application_fees/$id", {}, headers => $headers );
 }
@@ -307,6 +315,35 @@ Example:
     while ($customers = $stripe->next($customers)) {
         ...
     }
+
+=head2 create_recipient
+
+    create_recipient($data)
+
+Creates a recipient.
+The C<$data> hashref is required and must contain at least C<name> and
+C<type> (which can be C<individual> or C<corporate> as per Stripe's
+documentation), but can contain more (see Stripe Docs).
+Returns the recipient.
+
+Example:
+
+    $recipient = $stripe->create_recipient({
+        name => 'John Doe',
+        type => 'individual,
+    });
+
+
+=head2 get_recipient
+
+    get_recipient($id)
+
+Retrieves a recipient by id.
+Returns the recipient.
+
+Example:
+
+    $recipient = $stripe->get_recipient('rcp_123');
 
 =head2 create_card
 

--- a/t/12-recipients.t
+++ b/t/12-recipients.t
@@ -1,0 +1,33 @@
+use Test::Modern;
+use t::lib::Common qw(skip_unless_has_secret stripe :constants);
+
+skip_unless_has_secret;
+
+subtest 'basic stuff' => sub {
+    my $rcp = stripe->create_recipient(
+        { name => 'foo bar', type => 'individual' }
+    );
+    is $rcp->{name}, 'foo bar', '... Created a new recipient w/name';
+    is $rcp->{type}, 'individual', '... Created a new recipient w/type';
+
+    $rcp = stripe->get_recipient($rcp->{id});
+    is $rcp->{name}, 'foo bar', '... Fetched the created recipient';
+};
+
+subtest 'recipient with card' => sub {
+    my $rcp = stripe->create_recipient({
+        name => 'foo bar',
+        type => 'individual',
+        card => {
+            number    => STRIPE_CARD_VISA,
+            exp_month => 12,
+            exp_year  => 2020,
+        }
+    });
+
+    is $rcp->{name}, 'foo bar', '... Created a new recipient w/name';
+    is @{$rcp->{cards}{data}}, 1, '... Recipient has 1 card';
+    like $rcp->{default_card} => qr/card_.*/, '... Recipient has 1 card';
+};
+
+done_testing;


### PR DESCRIPTION
Even though `Recipient`s are [deprecated](https://stripe.com/docs/api#recipients), it is the way to do unreferenced refunds via the Stripe API for now (via [this](https://stripe.com/docs/tutorials/sending-transfers)).